### PR TITLE
Private zone option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Easily provision custom domains for:
 domain:
   component: '@serverless/domain'
   inputs:
+    privateZone: false
     domain: mywebsite.com
     subdomains:
       www: ${websiteComponentInstance}

--- a/serverless.js
+++ b/serverless.js
@@ -30,6 +30,7 @@ class Domain extends Component {
 
     this.context.debug(`Validating inputs.`)
     inputs.region = inputs.region || 'us-east-1'
+    inputs.privateZone = inputs.privateZone || false
 
     if (!inputs.domain) {
       throw Error(`"domain" is a required input.`)
@@ -44,12 +45,17 @@ class Domain extends Component {
     this.context.debug(`Formatting domains and identifying cloud services being used.`)
     const subdomains = prepareSubdomains(inputs)
     this.state.region = inputs.region
+    this.state.privateZone = JSON.parse(inputs.privateZone)
     this.state.domain = inputs.domain
     this.state.subdomains = subdomains
     await this.save()
 
     this.context.debug(`Getting the Hosted Zone ID for the domain ${inputs.domain}.`)
-    const domainHostedZoneId = await getDomainHostedZoneId(clients.route53, inputs.domain)
+    const domainHostedZoneId = await getDomainHostedZoneId(
+      clients.route53,
+      inputs.domain,
+      inputs.privateZone
+    )
 
     this.context.debug(
       `Searching for an AWS ACM Certificate based on the domain: ${inputs.domain}.`
@@ -172,7 +178,11 @@ class Domain extends Component {
     const clients = getClients(this.context.credentials.aws, this.state.region)
 
     this.context.debug(`Getting the Hosted Zone ID for the domain ${this.state.domain}.`)
-    const domainHostedZoneId = await getDomainHostedZoneId(clients.route53, this.state.domain)
+    const domainHostedZoneId = await getDomainHostedZoneId(
+      clients.route53,
+      this.state.domain,
+      this.state.privateZone
+    )
 
     for (const subdomain in this.state.subdomains) {
       const domainState = this.state.subdomains[subdomain]

--- a/utils.js
+++ b/utils.js
@@ -93,12 +93,12 @@ const getOutdatedDomains = (inputs, state) => {
  * - These don't need to be created and SHOULD NOT be modified.
  */
 
-const getDomainHostedZoneId = async (route53, domain) => {
+const getDomainHostedZoneId = async (route53, domain, privateZone) => {
   const hostedZonesRes = await route53.listHostedZonesByName().promise()
 
   const hostedZone = hostedZonesRes.HostedZones.find(
     // Name has a period at the end, so we're using includes rather than equals
-    (zone) => zone.Name.includes(domain)
+    (zone) => zone.Config.PrivateZone === privateZone && zone.Name.includes(domain)
   )
 
   if (!hostedZone) {


### PR DESCRIPTION
# Description

While using the [website](https://github.com/serverless-components/website) component I had a small problem that the component wasn't handling the dns creation as expected.

At my organisation we have 2 hosted zones for each dns, and by so, using the `Array.find` we're only retrieving the 1st occurrence, which leads the component to create a dns record at the private zone.

# Proposal

Add a new input parameter that has the default value of `false` and when provided with `true` we'll only look for private zones at the zones array.