### PR TITLE
CloudFront invalidation

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -660,7 +660,7 @@ const invalidateCloudfrontDistribution = async (cf, distributionId) => {
       CallerReference: String(Date.now()),
       Paths: {
         Quantity: 1,
-        Items: ['/index.html']
+        Items: ['/*']
       }
     }
   }


### PR DESCRIPTION
# Description

I might be wrong and probably there's a reason why you choose to only invalidate `/index.html` but if that's not the case and you just haven't tested all cases check this small update. 😬 

# Problem

I want to be able to invalidate all assets within my CDN distribution but the current implementation only invalidates a single file.

# Solution

Instead of invalidating a single file we can use a Regex expression to invalidate all assets that belongs to this distribution. 

