### PR TITLE
Add CloudFront alias to naked domain if subdomain is www

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -813,6 +813,11 @@ const addDomainToCloudfrontDistribution = async (cf, subdomain, certificateArn) 
     Items: [subdomain.domain]
   }
 
+  if (subdomain.domain.startsWith('www')) {
+    params.DistributionConfig.Aliases.Quantity = 2
+    params.DistributionConfig.Aliases.Items.push(`${subdomain.domain.replace('www.', '')}`)
+  }
+
   params.DistributionConfig.ViewerCertificate = {
     ACMCertificateArn: certificateArn,
     SSLSupportMethod: 'sni-only',


### PR DESCRIPTION
Otherwise you get a 403 forbidden error for the naked domain for domains that are deployed using addDomainToCloudfrontDistribution

This occurs only for subdomains of type awsCloudFront and not awsS3Website