### PR TITLE
#12 - Fix comparison to prevent selecting the wrong hosted zone id

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -112,8 +112,10 @@ const getDomainHostedZoneId = async (route53, domain, privateZone) => {
   const hostedZonesRes = await route53.listHostedZonesByName().promise()
 
   const hostedZone = hostedZonesRes.HostedZones.find(
-    // Name has a period at the end, so we're using includes rather than equals
-    (zone) => zone.Config.PrivateZone === privateZone && zone.Name.includes(domain)
+    // Name has a period at the end, so we're comparing it accordingly
+    (zone) =>
+      zone.Config.PrivateZone === privateZone &&
+      (zone.Name === domain || zone.Name === `${domain}.`)
   )
 
   if (!hostedZone) {


### PR DESCRIPTION
Change comparison of domain against hosted zone name to prevent selecting the wrong hosted zone id.