### PR TITLE
fix: make the check and replace processes use the smae key

### DIFF
--- a/serverless.js
+++ b/serverless.js
@@ -203,7 +203,7 @@ class Domain extends Component {
     const outputs = {}
     let hasRoot = false
     outputs.domains = subdomains.map((subdomain) => {
-      if (subdomain.domain.startsWith('www')) {
+      if (subdomain.domain.startsWith('www.')) {
         hasRoot = true
       }
       return `https://${subdomain.domain}`
@@ -255,7 +255,7 @@ class Domain extends Component {
             distribution.url
           )
 
-          if (domainState.domain.startsWith('www')) {
+          if (domainState.domain.startsWith('www.')) {
             await removeCloudFrontDomainDnsRecords(
               clients.route53,
               domainState.domain.replace('www.', ''), // it'll move on if it doesn't exist

--- a/utils.js
+++ b/utils.js
@@ -441,7 +441,7 @@ const configureDnsForCloudFrontDistribution = async (
     }
   }
 
-  if (subdomain.domain.startsWith('www')) {
+  if (subdomain.domain.startsWith('www.')) {
     dnsRecordParams.ChangeBatch.Changes.push({
       Action: 'UPSERT',
       ResourceRecordSet: {
@@ -678,7 +678,7 @@ const createCloudfrontDistribution = async (cf, subdomain, certificateArn) => {
     }
   }
 
-  if (subdomain.domain.startsWith('www')) {
+  if (subdomain.domain.startsWith('www.')) {
     params.DistributionConfig.Aliases.Quantity = 2
     params.DistributionConfig.Aliases.Items.push(`${subdomain.domain.replace('www.', '')}`)
   }
@@ -968,7 +968,7 @@ const addDomainToCloudfrontDistribution = async (cf, subdomain, certificateArn) 
     Items: [subdomain.domain]
   }
 
-  if (subdomain.domain.startsWith('www')) {
+  if (subdomain.domain.startsWith('www.')) {
     params.DistributionConfig.Aliases.Quantity = 2
     params.DistributionConfig.Aliases.Items.push(`${subdomain.domain.replace('www.', '')}`)
   }


### PR DESCRIPTION
`.startsWith('www')` and  `.replace('www.', '')` may cause unexpected bug.

For example:

```javascript
'www0www.example.com'.startsWith('www')  // => true
'www0www.example.com'.replace('www.', '')  // => 'www0example.com ' ; unexpected
```

This PR replaces `.startsWith('www')` with `.startsWith('www.')`.